### PR TITLE
Eng 10515 reconcile python client with voltdb repo

### DIFF
--- a/README
+++ b/README
@@ -60,13 +60,13 @@ FastSerializer(host, port, usessl, username, password, kerberos, dump_file_path,
     and password (string) is given, authenticate the client using them. If
     dump_file (string) is given, all the data received from and sent to the
     server will be written into the file pointed to by dump_file. If kerberos (bool)
-    is True, it use Kerberos to authenticate. If usessl (bool) is True, use ssl.
+    is True, use Kerberos to authenticate. If usessl (bool) is True, use ssl.
     A config file, ssl_config_file (string), can be specified to use Java KeyStore
     (JKS) data for the ssl connection. The connection supports three timeout
     settings: connect_timeout specifies how long to wait (integer)
-    for connection authentication, procedure_timeout (integer) to specify
+    for connection authentication, procedure_timeout (integer) specifies
     how long to wait for procedure calls and default_timeout (integer)
-    how long to wait for all other operations. All timeouts are specified
+    specifies how long to wait for all other operations. All timeouts are specified
     in seconds.
 
 FastSerializer.close()
@@ -149,6 +149,6 @@ Changes in V4
 - Requires minimum version of Python V2.5.
 - Processing of large (10K+) results sets sped up.
 
-Changes in V7.5
+Changes in V7.1
 - Support for SSL
 - Support for Kerberos

--- a/README
+++ b/README
@@ -54,11 +54,20 @@ FastSerializer.VOLTTYPE_DECIMAL_STRING
 FastSerializer.VOLTTYPE_VOLTTABLE
     VoltDB types.
 
-FastSerializer(host, port, username, password, dump_file)
+FastSerializer(host, port, usessl, username, password, kerberos, dump_file_path,
+               procedure_timeout, ssl_config_file)
     Create a connection to host (string) on port (integer). If username (string)
     and password (string) is given, authenticate the client using them. If
     dump_file (string) is given, all the data received from and sent to the
-    server will be written into the file pointed to by dump_file.
+    server will be written into the file pointed to by dump_file. If kerberos (bool)
+    is True, it use Kerberos to authenticate. If usessl (bool) is True, use ssl.
+    A config file, ssl_config_file (string), can be specified to use Java KeyStore
+    (JKS) data for the ssl connection. The connection supports three timeout
+    settings: connect_timeout specifies how long to wait (integer)
+    for connection authentication, procedure_timeout (integer) to specify
+    how long to wait for procedure calls and default_timeout (integer)
+    how long to wait for all other operations. All timeouts are specified
+    in seconds.
 
 FastSerializer.close()
     Closes the connection. No further use of the object is valid.
@@ -82,10 +91,10 @@ VoltProcedure.call(params, response, timeout)
 
 VoltResponse.status
     The status code (integer) for a stored procedure invocation. For a list of
-    status code, please refer to the VoltDB documentation.
+    status codes, please refer to the VoltDB documentation.
 
 VoltResponse.statusString
-    A human-friendly string of the meaning of the status code.
+    A human-friendly string with the meaning of the status code.
 
 VoltResponse.roundtripTime
     The round-trip time (integer) of the invocation in milliseconds.
@@ -139,3 +148,7 @@ Release Notes
 Changes in V4
 - Requires minimum version of Python V2.5.
 - Processing of large (10K+) results sets sped up.
+
+Changes in V7.5
+- Support for SSL
+- Support for Kerberos

--- a/voltdbclient.py
+++ b/voltdbclient.py
@@ -30,7 +30,10 @@ import socket
 import struct
 import datetime
 import decimal
-import hashlib
+try:
+    from hashlib import sha1 as sha
+except ImportError:
+    from sha import sha
 
 decimal.getcontext().prec = 38
 
@@ -270,9 +273,7 @@ class FastSerializer:
         # authentication is turned off.
 
         #protocol version
-        self.writeByte(1)
-        #sha256
-        self.writeByte(1)
+        self.writeByte(0)
 
         # service requested
         self.writeString("database")
@@ -284,8 +285,8 @@ class FastSerializer:
             # no username, just output length of 0
             self.writeString("")
 
-        # password supplied, sha-256 hash it
-        m = hashlib.sha256()
+        # password supplied, sha-1 hash it
+        m = sha()
         m.update(password)
         pwHash = m.digest()
         self.wbuf.extend(pwHash)

--- a/voltdbclient.py
+++ b/voltdbclient.py
@@ -27,13 +27,24 @@ if sys.hexversion < 0x02050000:
     raise Exception("Python version 2.5 or greater is required.")
 import array
 import socket
+import base64, textwrap
 import struct
 import datetime
 import decimal
+import hashlib
 try:
-    from hashlib import sha1 as sha
-except ImportError:
-    from sha import sha
+    import ssl
+    ssl_available = True
+except ImportError, e:
+    ssl_available = False
+    ssl_exception = e
+try:
+    import gssapi
+    kerberos_available = True
+except ImportError, e:
+    kerberos_available = False
+    kerberos_exception = e
+
 
 decimal.getcontext().prec = 38
 
@@ -72,6 +83,9 @@ class ReadBuffer(object):
     def buffer_length(self):
         return len(self._buf)
 
+    def remaining(self):
+        return (len(self._buf) - self._off)
+
     def get_buffer(self):
         return self._buf
 
@@ -89,6 +103,7 @@ class ReadBuffer(object):
             values = struct.unpack_from(format, self._buf, self._off)
         except struct.error, e:
             print 'Exception unpacking %d bytes using format "%s": %s' % (size, format, str(e))
+            raise e
         self.shift(size)
         return values
 
@@ -113,6 +128,8 @@ class FastSerializer:
     VOLTTYPE_MONEY = 20     # 8 byte long
     VOLTTYPE_VOLTTABLE = 21
     VOLTTYPE_VARBINARY = 25
+    VOLTTYPE_GEOGRAPHY_POINT = 26
+    VOLTTYPE_GEOGRAPHY = 27
 
     # SQL NULL indicator for object type serializations (string, decimal)
     NULL_STRING_INDICATOR = -1
@@ -126,6 +143,11 @@ class FastSerializer:
     # default decimal scale
     DEFAULT_DECIMAL_SCALE = 12
 
+    # protocol constants
+    AUTH_HANDSHAKE_VERSION = 2
+    AUTH_SERVICE_NAME = 4
+    AUTH_HANDSHAKE = 5
+
     # procedure call result codes
     PROC_OK = 0
 
@@ -134,25 +156,52 @@ class FastSerializer:
     # if these assumptions are not true. it is further assumed
     # that host order is little endian. See isNaN().
 
-    def __init__(self, host = None, port = 21212, username = "",
-                 password = "", dump_file_path = None,
+    # default ssl configuration
+    if (ssl_available):
+        DEFAULT_SSL_CONFIG = {
+        'keyfile': None,
+        'certfile': None,
+        'cert_reqs': ssl.CERT_NONE,
+        'ca_certs': None,
+        'do_handshake_on_connect': True
+        }
+    else:
+        DEFAULT_SSL_CONFIG = {}
+
+    def __init__(self, host = None, port = 21212, usessl = False,
+                 username = "", password = "",
+                 kerberos = False,
+                 dump_file_path = None,
                  connect_timeout = 8,
                  procedure_timeout = None,
-                 default_timeout = None):
+                 default_timeout = None,
+                 ssl_config_file = None,
+                 ssl_config = DEFAULT_SSL_CONFIG):
         """
         :param host: host string for connection or None
         :param port: port for connection or None
+        :param usessl: switch for use ssl or not
         :param username: authentication user name for connection or None
         :param password: authentication password for connection or None
+        :param kerberos: use Kerberos authentication
         :param dump_file_path: path to optional dump file or None
         :param connect_timeout: timeout (secs) or None for authentication (default=8)
         :param procedure_timeout: timeout (secs) or None for procedure calls (default=None)
         :param default_timeout: default timeout (secs) or None for all other operations (default=None)
+        :param ssl_config_file: config file that defines java keystore and truststore files
         """
         # connect a socket to host, port and get a file object
         self.wbuf = array.array('c')
         self.host = host
         self.port = port
+        self.usessl = usessl
+        if kerberos is None:
+            self.usekerberos = False
+        else:
+            self.usekerberos = kerberos
+        self.kerberosprinciple = None
+        self.ssl_config = ssl_config
+        self.ssl_config_file = ssl_config_file
         if not dump_file_path is None:
             self.dump_file = open(dump_file_path, "wb")
         else:
@@ -162,7 +211,15 @@ class FastSerializer:
 
         self.socket = None
         if self.host != None and self.port != None:
-            self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            ss = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            if (self.usessl):
+                if (ssl_available):
+                    self.socket = self.__wrap_socket(ss)
+                else:
+                    print "ERROR: To use SSL functionality please Install the Python ssl module."
+                    raise ssl_exception
+            else:
+                self.socket = ss
             self.socket.setblocking(1)
             self.socket.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
             self.socket.connect((self.host, self.port))
@@ -243,13 +300,93 @@ class FastSerializer:
 
         self.read_buffer = ReadBuffer()
 
-        if not username is None and not password is None and not host is None:
+        if self.usekerberos:
+            if not kerberos_available:
+                raise RuntimeError("Requested Kerberos authentication but unable to import the GSSAPI package.")
+            if not self.has_ticket():
+                raise RuntimeError("Requested Kerberos authentication but no valid ticket found. Authenticate with Kerberos first.")
+            assert not self.socket is None
+            self.socket.settimeout(connect_timeout)
+            self.authenticate(str(self.kerberosprinciple), "")
+        elif not username is None and not password is None and not host is None:
             assert not self.socket is None
             self.socket.settimeout(connect_timeout)
             self.authenticate(username, password)
 
         if self.socket:
             self.socket.settimeout(self.default_timeout)
+
+    def __wrap_socket(self, ss):
+        jks_config = {}
+        if self.ssl_config_file:
+            with open(self.ssl_config_file, 'r') as f:
+                lines = f.readlines()
+                for line in lines:
+                    k, v = line.strip().split('=')
+                    jks_config[k.lower()] = v
+
+        def write_pem(der_bytes, type, f):
+            f.write("-----BEGIN %s-----\n" % type)
+            f.write("\r\n".join(textwrap.wrap(base64.b64encode(der_bytes).decode('ascii'), 64)))
+            f.write("\n-----END %s-----\n" % type)
+
+        # extract key and certs
+        import jks
+        use_key_cert = False
+        if 'keystore' in jks_config and jks_config['keystore'] and \
+                'keystorepassword' in jks_config and jks_config['keystorepassword']:
+            ks = jks.KeyStore.load(jks_config['keystore'], jks_config['keystorepassword'])
+            keyfile = open(jks_config['keystore'] + '.key.pem', 'w')
+            certfile = open(jks_config['keystore'] + '.cert.pem', 'w')
+            for alias, pk in ks.private_keys.items():
+                # print("Private key: %s" % pk.alias)
+                if pk.algorithm_oid == jks.util.RSA_ENCRYPTION_OID:
+                    write_pem(pk.pkey, "RSA PRIVATE KEY", keyfile)
+                else:
+                    write_pem(pk.pkey_pkcs8, "PRIVATE KEY", keyfile)
+
+                for c in pk.cert_chain:
+                    write_pem(c[1], "CERTIFICATE", certfile)
+                use_key_cert = True
+            keyfile.close()
+            certfile.close()
+            if use_key_cert:
+                self.ssl_config['keyfile'] = keyfile.name
+                self.ssl_config['certfile'] = certfile.name
+
+        # extract ca certs
+        use_ca_cert = False
+        if 'truststore' in jks_config and jks_config['truststore'] and \
+                        'truststorepassword' in jks_config and jks_config['truststorepassword']:
+            ts = jks.KeyStore.load(jks_config['truststore'], jks_config['truststorepassword'])
+            cafile = open(jks_config['truststore'] + '.ca.cert.pem', 'w')
+            for alias, c in ts.certs.items():
+                # print("Certificate: %s" % c.alias)
+                write_pem(c.cert, "CERTIFICATE", cafile)
+                use_ca_cert = True
+            cafile.close()
+            if use_ca_cert:
+                self.ssl_config['ca_certs'] = cafile.name
+                self.ssl_config['cert_reqs'] = ssl.CERT_REQUIRED
+        elif 'cacerts' in jks_config and jks_config['cacerts']:
+            self.ssl_config['ca_certs'] = jks_config['cacerts']
+            self.ssl_config['cert_reqs'] = ssl.CERT_REQUIRED
+
+        # extract ssl_version
+        if 'ssl_version' in jks_config and jks_config['ssl_version']:
+            self.ssl_config['ca_certs'] = jks_config['ssl_version']
+        tlsv = None
+        try:
+            tlsv = ssl.PROTOCOL_TLSv1_2
+        except AttributeError, e:
+            print "WARNING: This version of python does not support TLSv1.2, upgrade to one that does"
+            tlsv = ssl.PROTOCOL_TLSv1
+
+        return ssl.wrap_socket(ss, self.ssl_config['keyfile'],
+                               self.ssl_config['certfile'], False,
+                               cert_reqs=self.ssl_config['cert_reqs'],
+                               ssl_version=tlsv,
+                               ca_certs=self.ssl_config['ca_certs'])
 
     def __compileStructs(self):
         # Compiled structs for each type
@@ -273,20 +410,25 @@ class FastSerializer:
         # authentication is turned off.
 
         #protocol version
-        self.writeByte(0)
+        self.writeByte(1)
+        #sha256
+        self.writeByte(1)
 
         # service requested
-        self.writeString("database")
+        if (self.usekerberos):
+            self.writeString("kerberos")
+        else:
+            self.writeString("database")
 
         if username:
-            # utf8 encode supplied username
+            # utf8 encode supplied username or kerberos principal name
             self.writeString(username)
         else:
             # no username, just output length of 0
             self.writeString("")
 
-        # password supplied, sha-1 hash it
-        m = sha()
+        # password supplied, sha-256 hash it
+        m = hashlib.sha256()
         m.update(password)
         pwHash = m.digest()
         self.wbuf.extend(pwHash)
@@ -298,16 +440,62 @@ class FastSerializer:
         try:
             self.bufferForRead()
         except IOError, e:
-            print "ERROR: Connection failed. Please check that the host and port are correct."
+            print "ERROR: Connection failed. Please check that the host, port and ssl settings are correct."
             raise e
         except socket.timeout:
-            raise SystemExit("Authentication timed out after %d seconds."
+            raise RuntimeError("Authentication timed out after %d seconds."
                                 % self.socket.gettimeout())
         version = self.readByte()
         status = self.readByte()
 
+        if (version == self.AUTH_HANDSHAKE_VERSION):
+            #service name supplied by VoltDB Server
+            service_string = self.readString().encode('ascii','ignore')
+            try:
+                service_name = gssapi.Name(service_string, name_type=gssapi.NameType.kerberos_principal)
+                ctx = gssapi.SecurityContext(name=service_name, mech=gssapi.MechType.kerberos)
+                in_token = None
+                out_token = ctx.step(in_token)
+                while not ctx.complete:
+                    self.writeByte(self.AUTH_HANDSHAKE_VERSION)
+                    self.writeByte(self.AUTH_HANDSHAKE)
+                    self.wbuf.extend(out_token)
+                    self.prependLength()
+                    self.flush()
+
+                    try:
+                        self.bufferForRead()
+                    except IOError, e:
+                        print "ERROR: Connection failed. Please check that the host, port and ssl settings are correct."
+                        raise e
+                    except socket.timeout:
+                        raise RuntimeError("Authentication timed out after %d seconds."
+                                            % self.socket.gettimeout())
+                    version = self.readByte()
+                    status = self.readByte()
+                    if version != self.AUTH_HANDSHAKE_VERSION or status != self.AUTH_HANDSHAKE:
+                        raise RuntimeError("Authentication failed.")
+
+                    in_token = self.readVarbinaryContent(self.read_buffer.remaining()).tostring()
+                    out_token = ctx.step(in_token)
+
+                try:
+                    self.bufferForRead()
+                except IOError, e:
+                    print "ERROR: Connection failed. Please check that the host, port and ssl settings are correct."
+                    raise e
+                except socket.timeout:
+                    raise RuntimeError("Authentication timed out after %d seconds."
+                                        % self.socket.gettimeout())
+                version = self.readByte()
+                status = self.readByte()
+
+            except Exception, e:
+                raise RuntimeError("Authentication failed.")
+
+
         if status != 0:
-            raise SystemExit("Authentication failed.")
+            raise RuntimeError("Authentication failed.")
 
         self.readInt32()
         self.readInt64()
@@ -315,6 +503,23 @@ class FastSerializer:
         self.readInt32()
         for x in range(self.readInt32()):
             self.readByte()
+
+    def has_ticket(self):
+        '''
+        Checks to see if the user has a valid ticket.
+        '''
+        default_cred = None
+        retval = False
+        try:
+            default_cred = gssapi.creds.Credentials(usage='initiate')
+            if default_cred.lifetime > 0:
+                self.kerberosprinciple = str(default_cred.name)
+                retval = True
+            else:
+                print "ERROR: Kerberos principal found but login expired."
+        except gssapi.raw.misc.GSSError as e:
+            print "ERROR: unable to find default principal from Kerberos cache."
+        return retval
 
     def setInputByteOrder(self, bom):
         # assuming bom is high bit set?
@@ -752,6 +957,7 @@ class VoltColumn:
     def __init__(self, fser = None, type = None, name = None):
         if fser != None:
             self.type = fser.readByte()
+            self.name = None
         elif type != None and name != None:
             self.type = type
             self.name = name
@@ -760,7 +966,7 @@ class VoltColumn:
         # If the name is empty, use the default "modified tuples". Has to do
         # this because HSQLDB doesn't return a column name if the table is
         # empty.
-        return "(%s: %d)" % (self.name and self.name or "modified tuples",
+        return "(%s: %d)" % (self.name or "modified tuples" ,
                              self.type)
 
     def __eq__(self, other):
@@ -784,7 +990,7 @@ class VoltTable:
     "definition and content of one VoltDB table"
     def __init__(self, fser):
         self.fser = fser
-        self.columns = []  # column defintions
+        self.columns = []  # column definitions
         self.tuples = []
 
     def __str__(self):
@@ -829,6 +1035,7 @@ class VoltTable:
     def readFromSerializer(self):
         # 1.
         tablesize = self.fser.readInt32()
+        limit_position = self.fser.read_buffer._off + tablesize
         # 2.
         headersize = self.fser.readInt32()
         statuscode = self.fser.readByte()
@@ -847,6 +1054,10 @@ class VoltTable:
             row = [self.fser.read(self.columns[j].type)
                    for j in xrange(columncount)]
             self.tuples.append(row)
+
+        # advance offset to end of table-size on read_buffer
+        if self.fser.read_buffer._off != limit_position:
+            self.fser.read_buffer._off = limit_position
 
         return self
 

--- a/voltdbclient.py
+++ b/voltdbclient.py
@@ -32,6 +32,7 @@ import struct
 import datetime
 import decimal
 import hashlib
+import os
 try:
     import ssl
     ssl_available = True
@@ -44,6 +45,12 @@ try:
 except ImportError, e:
     kerberos_available = False
     kerberos_exception = e
+try:
+    import jks
+    pyjks_available = True
+except ImportError, e:
+    pyjks_available = False
+    pyjks_exception = e
 
 
 decimal.getcontext().prec = 38
@@ -319,7 +326,7 @@ class FastSerializer:
     def __wrap_socket(self, ss):
         jks_config = {}
         if self.ssl_config_file:
-            with open(self.ssl_config_file, 'r') as f:
+            with open(os.path.expandvars(os.path.expanduser(self.ssl_config_file)), 'r') as f:
                 lines = f.readlines()
                 for line in lines:
                     k, v = line.strip().split('=')
@@ -331,7 +338,9 @@ class FastSerializer:
             f.write("\n-----END %s-----\n" % type)
 
         # extract key and certs
-        import jks
+        if not pyjks_available:
+            print "To use Java KeyStore please install the pyjks"
+            raise pyjks_exception
         use_key_cert = False
         if 'keystore' in jks_config and jks_config['keystore'] and \
                 'keystorepassword' in jks_config and jks_config['keystorepassword']:


### PR DESCRIPTION
This client is now identical to the voltdb community copy.  It supports:
1. ssl
2. kerberos

This will be packaged for download for customers who want to use python.  At some point it may move into the VoltDB repo along with the examples.